### PR TITLE
Refactor Button component to extend HTMLButtonElement attributes

### DIFF
--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -7,7 +7,7 @@ describe("Given the Button component", () => {
     test("Then it should show a 'Aniol' inside a button", () => {
       const buttonText = /Aniol/i;
 
-      render(<Button text={"Aniol"} />);
+      render(<Button children={"Aniol"} />);
 
       const button = screen.getByRole("button", {
         name: buttonText,
@@ -23,7 +23,7 @@ describe("Given the Button component", () => {
 
       render(
         <MemoryRouter>
-          <Button text="Test" linkTo="/home" />
+          <Button children="Test" linkTo="/home" />
         </MemoryRouter>,
       );
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,20 +1,17 @@
 import { Link } from "react-router";
+import { ButtonHTMLAttributes, PropsWithChildren } from "react";
 import "./Button.css";
 
-interface ButtonProps {
-  text: string;
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  children: string;
   linkTo?: string;
-  className?: string;
-  type?: "submit" | "reset";
-  isDisabled?: boolean;
 }
 
-const Button: React.FC<ButtonProps> = ({
-  text,
+const Button: React.FC<PropsWithChildren<ButtonProps>> = ({
+  children,
   className,
-  isDisabled,
-  type,
   linkTo,
+  ...props
 }) => {
   const buttonClassName = className
     ? `main-button ${className}`
@@ -22,15 +19,11 @@ const Button: React.FC<ButtonProps> = ({
 
   return linkTo ? (
     <Link className={buttonClassName} to={linkTo}>
-      {text}
+      {children}
     </Link>
   ) : (
-    <button
-      className={buttonClassName}
-      disabled={isDisabled}
-      type={type ?? "button"}
-    >
-      {text}
+    <button className={buttonClassName} {...props}>
+      {children}
     </button>
   );
 };

--- a/src/pages/NotFoundPage/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage/NotFoundPage.tsx
@@ -10,7 +10,7 @@ const NotFoundPage: React.FC = () => {
           This page doesn't exist. Not to worry, it happens to even the best
           riders & teams.
         </p>
-        <Button text="Go Back Home" linkTo="/home" />
+        <Button children="Go Back Home" linkTo="/home" />
       </div>
     </>
   );

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -51,6 +51,7 @@ input {
   padding: 0;
   border: 0;
   color: inherit;
+  appearance: none;
 }
 
 textarea {

--- a/src/team/components/TeamForm/TeamForm.css
+++ b/src/team/components/TeamForm/TeamForm.css
@@ -42,10 +42,19 @@
 
 .team-form__checkbox {
   width: 24px;
-  height: 24px;
+  aspect-ratio: 1;
   margin: 0;
   background-color: #fff;
   cursor: pointer;
+  border-radius: 8px;
+  padding: 0;
+}
+
+.team-form__checkbox:checked::after {
+  display: flex;
+  justify-content: center;
+  content: "✔";
+  color: #424242;
 }
 
 .team-form__description {

--- a/src/team/components/TeamForm/TeamForm.tsx
+++ b/src/team/components/TeamForm/TeamForm.tsx
@@ -83,7 +83,12 @@ const TeamForm: React.FC = () => {
           required
         ></textarea>
       </div>
-      <Button text={"Create team"} className="button__form" type="submit" />
+      <Button
+        children="Create team"
+        className="button__form"
+        type="submit"
+        disabled
+      />
     </form>
   );
 };


### PR DESCRIPTION
- Refactored `Button` component to extend `HTMLButtonElement` attributes and enabling to use all the button attributes without asking in ButtonProps.
- Implemented `PropsWithChildren`
- Added rest operator to allow to add new props to `<button>` element
- Changed default style for `TeamForm` checkbox adding `:checked` pseudo-class and `::after` pseudo-element