### PR TITLE
Feature/teams client create team method

### DIFF
--- a/src/team/client/TeamsClient.ts
+++ b/src/team/client/TeamsClient.ts
@@ -1,4 +1,4 @@
-import { Team } from "../types";
+import { Team, TeamWithoutId } from "../types";
 import { TeamsClientStructure } from "./types";
 
 export const apiRestUrl = import.meta.env.VITE_API_URL;
@@ -18,6 +18,28 @@ class TeamsClient implements TeamsClientStructure {
     }
 
     const { teams } = (await response.json()) as { teams: Team[] };
+
+    return teams;
+  }
+
+  async createTeam(teamData: TeamWithoutId): Promise<Team> {
+    const response = await fetch(`${this.apiRestUrl}/teams`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(teamData),
+    });
+
+    if (response.status === 409) {
+      throw new Error(`A team with ${teamData.name} name already exists`);
+    }
+
+    if (!response.ok) {
+      throw new Error("Failed to add a new team");
+    }
+
+    const { teams } = (await response.json()) as { teams: Team };
 
     return teams;
   }

--- a/src/team/client/__tests__/createTeam.test.ts
+++ b/src/team/client/__tests__/createTeam.test.ts
@@ -1,0 +1,23 @@
+import { TeamWithoutId } from "../../types";
+import TeamsClient from "../TeamsClient";
+
+describe("Given the createTeam method of TeamsClient class", () => {
+  describe("When it's called and receives the team name 'Aniol's team'", () => {
+    test("Then it should return a new team with the team name 'Aniol's team' with an _id", async () => {
+      const teamData: TeamWithoutId = {
+        name: "Refactor's team",
+        ridersNames: ["Aniol Rodriguez", "Erik Riquelme"],
+        championshipTitles: 3,
+        imageUrl: "https://refacto.com",
+        altImageText: "The motorbikes of Aniol's team",
+        description: "El equipo de Aniol",
+        debutYear: 1996,
+        isOfficialTeam: true,
+      };
+
+      const newTeam = await new TeamsClient().createTeam(teamData);
+
+      expect(newTeam).toEqual(expect.objectContaining(teamData));
+    });
+  });
+});

--- a/src/team/client/types.ts
+++ b/src/team/client/types.ts
@@ -1,5 +1,6 @@
-import { Team } from "../types";
+import { Team, TeamWithoutId } from "../types";
 
 export interface TeamsClientStructure {
   getTeams(): Promise<Team[]>;
+  createTeam(teamData: TeamWithoutId): Promise<Team>;
 }

--- a/src/team/mocks/handlers.ts
+++ b/src/team/mocks/handlers.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from "msw";
-import teamsMock from "./teamsMock";
+import teamsMock, { teamMock3 } from "./teamsMock";
 import { Team } from "../types";
 import { apiRestUrl } from "../client/TeamsClient";
 
@@ -11,6 +11,12 @@ export const handlers = [
   http.get(`${apiRestUrl}/teams`, () => {
     return HttpResponse.json<{ teams: Team[] }>({
       teams: teamsMock,
+    });
+  }),
+
+  http.post(`${apiRestUrl}/teams`, () => {
+    return HttpResponse.json<{ teams: Team }>({
+      teams: teamMock3,
     });
   }),
 ];

--- a/src/team/mocks/teamsMock.ts
+++ b/src/team/mocks/teamsMock.ts
@@ -5,22 +5,34 @@ export const teamMock1: Team = {
   name: "Aniol's team",
   ridersNames: ["Aniol Rodriguez", "Erik Riquelme"],
   championshipTitles: 3,
-  imageUrl: "",
+  imageUrl: "https://aniol.com",
   altImageText: "The motorbikes of Aniol's team",
-  description: "",
+  description: "El equipo de Aniol",
   debutYear: 1996,
   isOfficialTeam: true,
 };
 
 export const teamMock2: Team = {
-  _id: "36b8f84d-df4e-4d49-b662-bcde71a8764f",
+  _id: "36b8f84d-df4e-4d49-b662-bcde71a8764g",
   name: "Mario's team",
   ridersNames: ["Mario Gonzalez", "Refactor Gonsalo"],
   championshipTitles: 0,
-  imageUrl: "",
+  imageUrl: "https://refactor.com",
   altImageText: "The motorbikes of Mario's team",
-  description: "",
+  description: "El equipo de Mario",
   debutYear: 2024,
+  isOfficialTeam: true,
+};
+
+export const teamMock3: Team = {
+  _id: "36b8f84d-df4e-4d49-b662-bcde71a8764h",
+  name: "Refactor's team",
+  ridersNames: ["Aniol Rodriguez", "Erik Riquelme"],
+  championshipTitles: 3,
+  imageUrl: "https://refacto.com",
+  altImageText: "The motorbikes of Aniol's team",
+  description: "El equipo de Aniol",
+  debutYear: 1996,
   isOfficialTeam: true,
 };
 

--- a/src/team/types.ts
+++ b/src/team/types.ts
@@ -9,3 +9,5 @@ export interface Team {
   debutYear: number;
   isOfficialTeam: boolean;
 }
+
+export type TeamWithoutId = Omit<Team, "_id">;


### PR DESCRIPTION
- Added `createTeam` method in `TeamsClient` to send POST request to the API REST for team creation.
- Added unit test for the `createTeam` method
- Added new POST handler and a `teamMock3`