### PR TITLE
Feature/team data to api

### DIFF
--- a/src/team/components/TeamForm/TeamForm.test.tsx
+++ b/src/team/components/TeamForm/TeamForm.test.tsx
@@ -1,13 +1,16 @@
 import userEvent from "@testing-library/user-event";
 import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
 import TeamForm from "./TeamForm";
 
 describe("Given the TeamForm component", () => {
   const user = userEvent.setup();
 
+  const mockFunction = vi.fn();
+
   describe("When it's rendered", () => {
     test("Then it should show 'Name', 'Rider name 1', 'Rider name 2', 'Debut year in MotoGP', 'Is it a Official Team', 'Number of Championship titles', 'Image URL', 'Alternative Text' and 'Description' fields", () => {
-      render(<TeamForm />);
+      render(<TeamForm submitTeamData={mockFunction} />);
 
       const nameField = screen.getByLabelText("Name");
       const riderName1Field = screen.getByLabelText(/rider name 1/i);
@@ -37,7 +40,7 @@ describe("Given the TeamForm component", () => {
     test("Then it should show a disabled 'Create Team' button", () => {
       const buttonText = /create team/i;
 
-      render(<TeamForm />);
+      render(<TeamForm submitTeamData={mockFunction} />);
 
       const createTeamButton = screen.getByRole("button", {
         name: buttonText,
@@ -52,7 +55,7 @@ describe("Given the TeamForm component", () => {
     test("Then it should show 'Aniol's team' inside the Name field", async () => {
       const expectedNameFieldText = "Aniol's team";
 
-      render(<TeamForm />);
+      render(<TeamForm submitTeamData={mockFunction} />);
 
       const nameField = screen.getByLabelText("Name");
       await user.type(nameField, expectedNameFieldText);
@@ -63,7 +66,7 @@ describe("Given the TeamForm component", () => {
 
   describe("When the user fills all the fields", () => {
     test("Then the 'Create team' button should be enabled", async () => {
-      render(<TeamForm />);
+      render(<TeamForm submitTeamData={mockFunction} />);
 
       const nameField = screen.getByLabelText("Name");
       const riderName1Field = screen.getByLabelText(/rider name 1/i);

--- a/src/team/components/TeamForm/TeamForm.tsx
+++ b/src/team/components/TeamForm/TeamForm.tsx
@@ -1,15 +1,21 @@
 import { useEffect } from "react";
 import Button from "../../../components/Button/Button";
 import useTeamForm from "../../hooks/useTeamForm";
+import { TeamWithoutId } from "../../types";
 import "./TeamForm.css";
 
-const TeamForm: React.FC = () => {
+interface TeamFormProps {
+  submitTeamData: (teamData: TeamWithoutId) => void;
+}
+
+const TeamForm: React.FC<TeamFormProps> = ({ submitTeamData }) => {
   const {
     teamData,
     updateTeamData,
     handleCheckBoxState,
     isButtonDisabled,
     isValidForm,
+    transformTeamFormData,
   } = useTeamForm();
 
   const {
@@ -24,12 +30,20 @@ const TeamForm: React.FC = () => {
     description,
   } = teamData;
 
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const teamWithoutId = transformTeamFormData(teamData);
+
+    submitTeamData(teamWithoutId);
+  };
+
   useEffect(() => {
     isValidForm();
   }, [isValidForm]);
 
   return (
-    <form className="team-form">
+    <form className="team-form" onSubmit={handleSubmit}>
       <div className="team-form__info">
         <label htmlFor="name">Name</label>
         <input

--- a/src/team/hooks/useTeamForm.ts
+++ b/src/team/hooks/useTeamForm.ts
@@ -1,5 +1,6 @@
 import { useState } from "react";
-import { TeamFormData } from "../types";
+import { TeamFormData, TeamWithoutId } from "../types";
+import TeamsClient from "../client/TeamsClient";
 
 const useTeamForm = () => {
   const [isButtonDisabled, setIsButtonDisabled] = useState(true);
@@ -54,12 +55,47 @@ const useTeamForm = () => {
     setIsButtonDisabled(!isValid);
   };
 
+  const transformTeamFormData = (teamData: TeamFormData): TeamWithoutId => {
+    const {
+      riderName1,
+      riderName2,
+      altImageText,
+      championshipTitles,
+      debutYear,
+      description,
+      imageUrl,
+      isOfficialTeam,
+      name,
+    } = teamData;
+
+    return {
+      name: name,
+      ridersNames: [riderName1, riderName2],
+      debutYear: debutYear,
+      isOfficialTeam: isOfficialTeam,
+      championshipTitles: championshipTitles,
+      imageUrl: imageUrl,
+      altImageText: altImageText,
+      description: description,
+    };
+  };
+
+  const createTeam = (teamData: TeamWithoutId) => {
+    const teamsClient = new TeamsClient();
+
+    const newTeam = teamsClient.createTeam(teamData);
+
+    return newTeam;
+  };
+
   return {
     teamData,
     updateTeamData,
     handleCheckBoxState,
     isValidForm,
     isButtonDisabled,
+    transformTeamFormData,
+    createTeam,
   };
 };
 

--- a/src/team/pages/AddNewTeamPage/AddNewTeamPage.tsx
+++ b/src/team/pages/AddNewTeamPage/AddNewTeamPage.tsx
@@ -1,10 +1,18 @@
 import TeamForm from "../../components/TeamForm/TeamForm";
+import useTeamForm from "../../hooks/useTeamForm";
+import { TeamWithoutId } from "../../types";
 
 const AddNewTeamPage: React.FC = () => {
+  const { createTeam } = useTeamForm();
+
+  const sendTeamDataToApiRest = async (teamData: TeamWithoutId) => {
+    await createTeam(teamData);
+  };
+
   return (
     <>
       <h1 className="page-title">Add new team</h1>
-      <TeamForm />
+      <TeamForm submitTeamData={sendTeamDataToApiRest} />
     </>
   );
 };


### PR DESCRIPTION
- Created `transformTeamFormData` and `createTeam` functions to convert to convert `riderName1` and `riderName2` to `ridersNames` property and the `createTeam` function to send the transformed team data to the API REST.
- Handled form submission with `event.preventdefault()`, implement `transformTeamFormData` function and ask for TeamFormProps `submitTeamData` function