### PR TITLE
Feature/teams client delete team

### DIFF
--- a/src/team/client/TeamsClient.ts
+++ b/src/team/client/TeamsClient.ts
@@ -43,6 +43,20 @@ class TeamsClient implements TeamsClientStructure {
 
     return teams;
   }
+
+  async deleteTeam(teamId: string): Promise<Team> {
+    const response = await fetch(`${this.apiRestUrl}/teams/${teamId}`, {
+      method: "DELETE",
+    });
+
+    if (!response.ok) {
+      throw new Error("Failed to delete a team");
+    }
+
+    const { team } = (await response.json()) as { team: Team };
+
+    return team;
+  }
 }
 
 export default TeamsClient;

--- a/src/team/client/__tests__/deleteTeam.test.ts
+++ b/src/team/client/__tests__/deleteTeam.test.ts
@@ -1,0 +1,14 @@
+import { teamMock3 } from "../../mocks/teamsMock";
+import TeamsClient from "../TeamsClient";
+
+describe("Given the deleteTeam of the TeamsClient class", () => {
+  describe("When is called with the team 'Aniol's team' with the ID '36b8f84d-df4e-4d49-b662-bcde71a8764g'", () => {
+    test("Then it should return the 'Aniol's team'", async () => {
+      const deletedTeam = await new TeamsClient().deleteTeam(
+        "36b8f84d-df4e-4d49-b662-bcde71a8764g",
+      );
+
+      expect(deletedTeam).toEqual(teamMock3);
+    });
+  });
+});

--- a/src/team/client/types.ts
+++ b/src/team/client/types.ts
@@ -3,4 +3,5 @@ import { Team, TeamWithoutId } from "../types";
 export interface TeamsClientStructure {
   getTeams(): Promise<Team[]>;
   createTeam(teamData: TeamWithoutId): Promise<Team>;
+  deleteTeam(teamId: string): Promise<Team>;
 }

--- a/src/team/mocks/handlers.ts
+++ b/src/team/mocks/handlers.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from "msw";
-import teamsMock, { teamMock3 } from "./teamsMock";
+import teamsMock, { teamMock2, teamMock3 } from "./teamsMock";
 import { Team } from "../types";
 import { apiRestUrl } from "../client/TeamsClient";
 
@@ -17,6 +17,12 @@ export const handlers = [
   http.post(`${apiRestUrl}/teams`, () => {
     return HttpResponse.json<{ teams: Team }>({
       teams: teamMock3,
+    });
+  }),
+
+  http.delete(`${apiRestUrl}/teams/${teamMock2._id}`, () => {
+    return HttpResponse.json<{ team: Team }>({
+      team: teamMock3,
     });
   }),
 ];


### PR DESCRIPTION
- Created `deleteTeam` method of `TeamsClient`.  When the it is not possible to delete the team due to a bad response, the client will throw a new `Error`
- Added test case for deleteTeam method and set up delete handler.  Tested the happy path