### PR TITLE
Feature/teams client get team by

### DIFF
--- a/src/team/client/TeamsClient.ts
+++ b/src/team/client/TeamsClient.ts
@@ -57,6 +57,18 @@ class TeamsClient implements TeamsClientStructure {
 
     return team;
   }
+
+  async getTeamById(teamId: string): Promise<Team> {
+    const response = await fetch(`${this.apiRestUrl}/teams/${teamId}`);
+
+    if (!response.ok) {
+      throw new Error("Failed to load the team");
+    }
+
+    const { team } = (await response.json()) as { team: Team };
+
+    return team;
+  }
 }
 
 export const teamsClient = new TeamsClient();

--- a/src/team/client/__tests__/getTeamById.test.ts
+++ b/src/team/client/__tests__/getTeamById.test.ts
@@ -1,0 +1,12 @@
+import { teamMock1 } from "../../mocks/teamsMock";
+import { teamsClient } from "../TeamsClient";
+
+describe("Given the getTeamById of the TeamsClient class", () => {
+  describe("When is called with the team 'Aniol's team' with the ID '36b8f84d-df4e-4d49-b662-bcde71a8764g'", () => {
+    test("Then it should return the 'Aniol's team'", async () => {
+      const team = await teamsClient.getTeamById(teamMock1._id);
+
+      expect(team).toEqual(teamMock1);
+    });
+  });
+});

--- a/src/team/client/types.ts
+++ b/src/team/client/types.ts
@@ -4,4 +4,5 @@ export interface TeamsClientStructure {
   getTeams(): Promise<Team[]>;
   createTeam(teamData: TeamWithoutId): Promise<Team>;
   deleteTeam(teamId: string): Promise<Team>;
+  getTeamById(teamId: string): Promise<Team>;
 }

--- a/src/team/mocks/handlers.ts
+++ b/src/team/mocks/handlers.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from "msw";
-import teamsMock, { teamMock2, teamMock3 } from "./teamsMock";
+import teamsMock, { teamMock1, teamMock2, teamMock3 } from "./teamsMock";
 import { Team } from "../types";
 import { apiRestUrl } from "../client/TeamsClient";
 
@@ -23,6 +23,12 @@ export const handlers = [
   http.delete(`${apiRestUrl}/teams/${teamMock2._id}`, () => {
     return HttpResponse.json<{ team: Team }>({
       team: teamMock2,
+    });
+  }),
+
+  http.get(`${apiRestUrl}/teams/${teamMock1._id}`, () => {
+    return HttpResponse.json<{ team: Team }>({
+      team: teamMock1,
     });
   }),
 ];


### PR DESCRIPTION
- Created `getTeamById` method of `TeamsClient` class. If the received response is not successful the client will throw a 'Failed to load the team' error.
- Added happy path test case for getTeamById method
