### PR TITLE
Feature/details button navigate

### DIFF
--- a/src/components/NavMenu/NavMenu.tsx
+++ b/src/components/NavMenu/NavMenu.tsx
@@ -12,7 +12,7 @@ const NavMenu: React.FC = () => {
             return (
               <>
                 <img
-                  src={isActive ? "icons/home_black.svg" : "icons/home.svg"}
+                  src={isActive ? "/icons/home_black.svg" : "/icons/home.svg"}
                   alt="Go to home page"
                   width={30}
                   height={30}
@@ -30,7 +30,9 @@ const NavMenu: React.FC = () => {
               <>
                 <img
                   src={
-                    isActive ? "icons/add-team_black.svg" : "icons/add-team.svg"
+                    isActive
+                      ? "/icons/add-team_black.svg"
+                      : "/icons/add-team.svg"
                   }
                   alt="Go to add new team page"
                   width={30}

--- a/src/router/AppRouter.test.tsx
+++ b/src/router/AppRouter.test.tsx
@@ -6,7 +6,12 @@ import { Provider } from "react-redux";
 import { store } from "../store";
 import { server } from "../mocks/node";
 import { apiRestUrl } from "../team/client/TeamsClient";
-import { addNewTeamPage, notFoundPage, teamsPage } from "./routes";
+import {
+  addNewTeamPage,
+  notFoundPage,
+  teamDetailPage,
+  teamsPage,
+} from "./routes";
 import AppRouter from "./AppRouter";
 import { teamMock1, teamMock2 } from "../team/mocks/teamsMock";
 import { Team } from "../team/types";
@@ -353,6 +358,27 @@ describe("Given the AppRouter component", () => {
         });
 
         expect(pageTitle).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("When it is rendered at '/teams/:teamId", () => {
+    describe("When it receives the team id '36b8f84d-df4e-4d49-b662-bcde71a8764f'", () => {
+      test("Then it should show 'Aniol's team' inside a heading", async () => {
+        const expectedTitleText = /Aniol's team/i;
+
+        render(
+          <MemoryRouter initialEntries={[`${teamDetailPage}/${teamMock1._id}`]}>
+            <Provider store={store}>
+              <AppRouter />
+            </Provider>
+          </MemoryRouter>,
+        );
+        const title = await screen.findByRole("heading", {
+          name: expectedTitleText,
+        });
+
+        expect(title).toBeInTheDocument();
       });
     });
   });

--- a/src/router/AppRouter.tsx
+++ b/src/router/AppRouter.tsx
@@ -2,10 +2,14 @@ import { lazy } from "react";
 import { Route, Navigate, Routes } from "react-router";
 import App from "../components/App/App";
 import TeamsPage from "../team/pages/TeamsPage/TeamsPage";
-import { addNewTeamPage, teamsPage } from "./routes";
+import { addNewTeamPage, teamDetailPage, teamsPage } from "./routes";
 
 export const NotFoundPage = lazy(
   () => import("../pages/NotFoundPage/NotFoundPage"),
+);
+
+export const TeamDetailPage = lazy(
+  () => import("../team/pages/TeamDetailPage/TeamDetailPage"),
 );
 
 export const AddNewTeamPage = lazy(
@@ -19,6 +23,10 @@ const AppRouter: React.FC = () => {
         <Route index element={<Navigate to={teamsPage} />} />
         <Route path={teamsPage} element={<TeamsPage />} />
         <Route path={addNewTeamPage} element={<AddNewTeamPage />} />
+        <Route
+          path={`${teamDetailPage}/:teamId`}
+          element={<TeamDetailPage />}
+        />
         <Route path="*" element={<NotFoundPage />} />
       </Route>
     </Routes>

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -1,7 +1,9 @@
 const raceinatorRoutes = {
   teamsPage: "/home",
   addNewTeamPage: "/new-team",
+  teamDetailPage: "/teams",
   notFoundPage: "/home1",
 };
 
-export const { teamsPage, addNewTeamPage, notFoundPage } = raceinatorRoutes;
+export const { teamsPage, addNewTeamPage, teamDetailPage, notFoundPage } =
+  raceinatorRoutes;

--- a/src/team/components/TeamCard/TeamCard.test.tsx
+++ b/src/team/components/TeamCard/TeamCard.test.tsx
@@ -3,6 +3,7 @@ import { Provider } from "react-redux";
 import { store } from "../../../store";
 import { teamMock1 } from "../../mocks/teamsMock";
 import TeamCard from "./TeamCard";
+import { MemoryRouter } from "react-router";
 
 describe("Given the TeamCard component", () => {
   describe("When it receives a team with the name 'Aniol's team'", () => {
@@ -10,9 +11,11 @@ describe("Given the TeamCard component", () => {
       const expectedAltImageText = /The motorbikes of Aniol's team/i;
 
       render(
-        <Provider store={store}>
-          <TeamCard team={teamMock1} />
-        </Provider>,
+        <MemoryRouter>
+          <Provider store={store}>
+            <TeamCard team={teamMock1} />
+          </Provider>
+        </MemoryRouter>,
       );
 
       const teamCardAltImage = screen.getByAltText(expectedAltImageText);
@@ -24,9 +27,11 @@ describe("Given the TeamCard component", () => {
       const expectedNameText = /Aniol's team/i;
 
       render(
-        <Provider store={store}>
-          <TeamCard team={teamMock1} />
-        </Provider>,
+        <MemoryRouter>
+          <Provider store={store}>
+            <TeamCard team={teamMock1} />
+          </Provider>
+        </MemoryRouter>,
       );
 
       const teamName = screen.getByRole("heading", {
@@ -40,9 +45,11 @@ describe("Given the TeamCard component", () => {
       const expectedNameText = /Team riders/i;
 
       render(
-        <Provider store={store}>
-          <TeamCard team={teamMock1} />
-        </Provider>,
+        <MemoryRouter>
+          <Provider store={store}>
+            <TeamCard team={teamMock1} />
+          </Provider>
+        </MemoryRouter>,
       );
 
       const teamRidersTitle = screen.getByRole("heading", {
@@ -54,9 +61,11 @@ describe("Given the TeamCard component", () => {
 
     test("Then it should show 'Aniol Rodriguez and 'Erik Riquelme' texts", () => {
       render(
-        <Provider store={store}>
-          <TeamCard team={teamMock1} />
-        </Provider>,
+        <MemoryRouter>
+          <Provider store={store}>
+            <TeamCard team={teamMock1} />
+          </Provider>
+        </MemoryRouter>,
       );
 
       const teamRider1 = screen.getByText(/Aniol Rodriguez/i);
@@ -66,13 +75,33 @@ describe("Given the TeamCard component", () => {
       expect(teamRider2).toBeInTheDocument();
     });
 
+    test("Then it should show a 'Details' button", () => {
+      const expectedButtonName = /Details/i;
+
+      render(
+        <MemoryRouter>
+          <Provider store={store}>
+            <TeamCard team={teamMock1} />
+          </Provider>
+        </MemoryRouter>,
+      );
+
+      const button = screen.getByRole("button", {
+        name: expectedButtonName,
+      });
+
+      expect(button).toBeInTheDocument();
+    });
+
     test("Then it should show a 'Delete' button", () => {
       const expectedButtonName = /Delete/i;
 
       render(
-        <Provider store={store}>
-          <TeamCard team={teamMock1} />
-        </Provider>,
+        <MemoryRouter>
+          <Provider store={store}>
+            <TeamCard team={teamMock1} />
+          </Provider>
+        </MemoryRouter>,
       );
 
       const button = screen.getByRole("button", {

--- a/src/team/components/TeamCard/TeamCard.tsx
+++ b/src/team/components/TeamCard/TeamCard.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from "react-router";
 import { displayLoading, hideLoading } from "../../../uiSlice";
 import { useAppDispatch } from "../../../store/hooks";
 import Button from "../../../components/Button/Button";
@@ -6,6 +7,7 @@ import useTeams from "../../hooks/useTeams";
 import { deleteTeamError } from "../../toasts/errors/errors";
 import { deleteTeamFeedback } from "../../toasts/success/success";
 import { Team } from "../../types";
+import { teamDetailPage } from "../../../router/routes";
 import "./TeamCard.css";
 
 interface TeamCardProps {
@@ -17,6 +19,7 @@ const TeamCard: React.FC<TeamCardProps> = ({ team, loading = "lazy" }) => {
   const { imageUrl, altImageText, name, ridersNames, _id } = team;
   const { fetchTeams } = useTeams();
   const dispatch = useAppDispatch();
+  const navigate = useNavigate();
 
   const deleteTeams = async () => {
     dispatch(displayLoading());
@@ -32,6 +35,10 @@ const TeamCard: React.FC<TeamCardProps> = ({ team, loading = "lazy" }) => {
       dispatch(hideLoading());
       deleteTeamError(error as Error);
     }
+  };
+
+  const navigateToTeamDetailPage = () => {
+    navigate(`${teamDetailPage}/${team._id}`);
   };
 
   return (
@@ -52,7 +59,11 @@ const TeamCard: React.FC<TeamCardProps> = ({ team, loading = "lazy" }) => {
           <span>{ridersNames[1]}</span>
         </div>
         <div className="button__container">
-          <Button className="details-button" children="Details" />
+          <Button
+            className="details-button"
+            children="Details"
+            onClick={navigateToTeamDetailPage}
+          />
           <Button children="Delete" onClick={deleteTeams} />
         </div>
       </div>

--- a/src/team/components/TeamDetail/TeamDetail.test.tsx
+++ b/src/team/components/TeamDetail/TeamDetail.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import TeamDetail from "./TeamDetail";
+import { teamMock1 } from "../../mocks/teamsMock";
+
+describe("Given the TeamDetail component", () => {
+  describe("When it receives 'Aniol's team' team", () => {
+    test("Then it should show 'Aniol's team' inside a heading", () => {
+      const expectedTitleText = /Aniol's team/i;
+
+      render(<TeamDetail team={teamMock1} />);
+
+      const title = screen.getByRole("heading", {
+        name: expectedTitleText,
+      });
+
+      expect(title).toBeInTheDocument();
+    });
+  });
+});

--- a/src/team/components/TeamForm/TeamForm.css
+++ b/src/team/components/TeamForm/TeamForm.css
@@ -54,7 +54,7 @@
   display: flex;
   justify-content: center;
   content: "✔";
-  color: #424242;
+  color: var(--button-secondary-main-color);
 }
 
 .team-form__description {

--- a/src/team/components/TeamsList/TeamsList.test.tsx
+++ b/src/team/components/TeamsList/TeamsList.test.tsx
@@ -3,6 +3,7 @@ import { Provider } from "react-redux";
 import { store } from "../../../store";
 import TeamsList from "./TeamsList";
 import teamsMock from "../../mocks/teamsMock";
+import { MemoryRouter } from "react-router";
 
 describe("Given the TeamsList component", () => {
   describe("When it receives a list of teams with 'Aniol's team' and 'Mario's team'", () => {
@@ -11,9 +12,11 @@ describe("Given the TeamsList component", () => {
       const expectedTeam2AltText = /The motorbikes of Mario's team/i;
 
       render(
-        <Provider store={store}>
-          <TeamsList teams={teamsMock} />
-        </Provider>,
+        <MemoryRouter>
+          <Provider store={store}>
+            <TeamsList teams={teamsMock} />
+          </Provider>
+        </MemoryRouter>,
       );
 
       const team1AlternativeText = screen.getByAltText(expectedTeam1AltText);
@@ -28,9 +31,11 @@ describe("Given the TeamsList component", () => {
       const expectedTeamNameText2 = /Mario's team/i;
 
       render(
-        <Provider store={store}>
-          <TeamsList teams={teamsMock} />
-        </Provider>,
+        <MemoryRouter>
+          <Provider store={store}>
+            <TeamsList teams={teamsMock} />
+          </Provider>
+        </MemoryRouter>,
       );
 
       const teamName1 = screen.getByRole("heading", {

--- a/src/team/hooks/useTeams.ts
+++ b/src/team/hooks/useTeams.ts
@@ -1,7 +1,7 @@
 import { useCallback } from "react";
 import { loadTeams } from "../slice";
 import { useAppSelector, useAppDispatch } from "../../store/hooks";
-import { loadingTeamError } from "../toasts/errors/errors";
+import { loadTeamsError } from "../toasts/errors/errors";
 import { displayLoading, hideLoading } from "../../uiSlice";
 import { teamsClient } from "../client/TeamsClient";
 
@@ -21,7 +21,7 @@ const useTeams = () => {
       dispatch(hideLoading());
     } catch {
       dispatch(hideLoading());
-      loadingTeamError();
+      loadTeamsError();
     }
   }, [dispatch]);
 

--- a/src/team/pages/TeamDetailPage/TeamDetailPage.tsx
+++ b/src/team/pages/TeamDetailPage/TeamDetailPage.tsx
@@ -5,7 +5,7 @@ import TeamDetail from "../../components/TeamDetail/TeamDetail";
 import { teamsClient } from "../../client/TeamsClient";
 import { loadTeam } from "../../slice";
 import { displayLoading, hideLoading } from "../../../uiSlice";
-import { loadingTeamError } from "../../toasts/errors/errors";
+import { loadTeamDetailError } from "../../toasts/errors/errors";
 
 const TeamDetailPage: React.FC = () => {
   const { teamId } = useParams<{ teamId: string }>();
@@ -23,7 +23,7 @@ const TeamDetailPage: React.FC = () => {
       dispatch(hideLoading());
     } catch {
       dispatch(hideLoading());
-      loadingTeamError();
+      loadTeamDetailError();
     }
   }, [dispatch, teamId]);
 

--- a/src/team/pages/TeamsPage/TeamsPage.test.tsx
+++ b/src/team/pages/TeamsPage/TeamsPage.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen } from "@testing-library/react";
+import TeamsPage from "./TeamsPage";
 import { Provider } from "react-redux";
 import { store } from "../../../store";
-import TeamsPage from "./TeamsPage";
+import { MemoryRouter } from "react-router";
 
 describe("Given the TeamsPage component", () => {
   describe("When it's rendered", () => {
@@ -40,9 +41,11 @@ describe("Given the TeamsPage component", () => {
       const expectedTeam2AltText = /The motorbikes of Mario's team/i;
 
       render(
-        <Provider store={store}>
-          <TeamsPage />
-        </Provider>,
+        <MemoryRouter>
+          <Provider store={store}>
+            <TeamsPage />
+          </Provider>
+        </MemoryRouter>,
       );
 
       const team1AlternativeText =
@@ -59,9 +62,11 @@ describe("Given the TeamsPage component", () => {
       const expectedTeamNameText2 = /Mario's team/i;
 
       render(
-        <Provider store={store}>
-          <TeamsPage />
-        </Provider>,
+        <MemoryRouter>
+          <Provider store={store}>
+            <TeamsPage />
+          </Provider>
+        </MemoryRouter>,
       );
 
       const teamName1 = await screen.findByRole("heading", {

--- a/src/team/toasts/errors/errors.tsx
+++ b/src/team/toasts/errors/errors.tsx
@@ -1,8 +1,16 @@
 import { toast } from "react-toastify";
 import "./errors.css";
 
-export const loadingTeamError = () => {
+export const loadTeamsError = () => {
   toast.error(`Failed to load teams`, {
+    className: "toast__errors",
+    closeButton: false,
+    icon: <img src="/icons/alert.svg" alt="" />,
+  });
+};
+
+export const loadTeamDetailError = () => {
+  toast.error(`Failed to load team information`, {
     className: "toast__errors",
     closeButton: false,
     icon: <img src="/icons/alert.svg" alt="" />,

--- a/src/team/toasts/errors/errors.tsx
+++ b/src/team/toasts/errors/errors.tsx
@@ -5,7 +5,7 @@ export const loadingTeamError = () => {
   toast.error(`Failed to load teams`, {
     className: "toast__errors",
     closeButton: false,
-    icon: <img src="icons/alert.svg" alt="" />,
+    icon: <img src="/icons/alert.svg" alt="" />,
   });
 };
 
@@ -17,7 +17,7 @@ export const addNewTeamError = (error: Error) => {
     {
       closeButton: false,
       className: "toast__errors",
-      icon: <img src="icons/alert.svg" alt="" />,
+      icon: <img src="/icons/alert.svg" alt="" />,
     },
   );
 };
@@ -30,7 +30,7 @@ export const deleteTeamError = (error: Error) => {
     {
       closeButton: false,
       className: "toast__errors",
-      icon: <img src="icons/alert.svg" alt="" />,
+      icon: <img src="/icons/alert.svg" alt="" />,
     },
   );
 };

--- a/src/team/toasts/success/success.tsx
+++ b/src/team/toasts/success/success.tsx
@@ -12,6 +12,6 @@ export const deleteTeamFeedback = () => {
   toast.success(`Team deleted`, {
     className: "toast__success",
     closeButton: false,
-    icon: <img src="icons/bin.svg" alt="" />,
+    icon: <img src="/icons/bin.svg" alt="" />,
   });
 };


### PR DESCRIPTION
- Added TeamDetailPage navigation route and correct src `img`. Also lazy load `TeamDetailPage`
- Implement TeamDetailPage navigation into the 'Details' button. Added navigation to the `TeamDetailPage` on button onClick.
- Added test case for 'Details' button and add MemoryRouter to tests cases. Test case that button is rendered.
- Created loadTeamDetailError function. Added custom message for when the client can't get the team data.
- Added test case for `TeamDetail` component. Tested what's rendered with team example.
- Added test case for `TeamDetailPage` component. Tested what's is rendered when the user goes to that url.