### PR TITLE
Feature/team card details link

### DIFF
--- a/src/components/Button/Button.css
+++ b/src/components/Button/Button.css
@@ -6,4 +6,5 @@
   background-color: var(--button-main-color);
   width: 97px;
   height: 40px;
+  text-align: center;
 }

--- a/src/router/AppRouter.test.tsx
+++ b/src/router/AppRouter.test.tsx
@@ -95,6 +95,33 @@ describe("Given the AppRouter component", () => {
       });
     });
 
+    describe("And when the user clicks to 'Details' link from 'Aniol's team'", () => {
+      test("Then it should show 'Aniol's team' inside a heading", async () => {
+        const pageTitleText = /Aniol's team/i;
+        const linkText = /Details/i;
+
+        render(
+          <MemoryRouter initialEntries={[teamsPage]}>
+            <Provider store={store}>
+              <AppRouter />
+            </Provider>
+          </MemoryRouter>,
+        );
+
+        const addNewTeamLink = await screen.findAllByRole("link", {
+          name: linkText,
+        });
+
+        await user.click(addNewTeamLink[0]);
+
+        const pageTitle = await screen.findByRole("heading", {
+          name: pageTitleText,
+        });
+
+        expect(pageTitle).toBeInTheDocument();
+      });
+    });
+
     describe("And when the client throws an error with 'Failed to load teams'", () => {
       test("Then it should show a toast with the message 'Failed to load teams", async () => {
         const toastText = /Failed to load teams/i;

--- a/src/team/components/TeamCard/TeamCard.test.tsx
+++ b/src/team/components/TeamCard/TeamCard.test.tsx
@@ -76,7 +76,7 @@ describe("Given the TeamCard component", () => {
     });
 
     test("Then it should show a 'Details' button", () => {
-      const expectedButtonName = /Details/i;
+      const expectedLinkName = /Details/i;
 
       render(
         <MemoryRouter>
@@ -86,11 +86,11 @@ describe("Given the TeamCard component", () => {
         </MemoryRouter>,
       );
 
-      const button = screen.getByRole("button", {
-        name: expectedButtonName,
+      const link = screen.getByRole("link", {
+        name: expectedLinkName,
       });
 
-      expect(button).toBeInTheDocument();
+      expect(link).toBeInTheDocument();
     });
 
     test("Then it should show a 'Delete' button", () => {

--- a/src/team/components/TeamCard/TeamCard.tsx
+++ b/src/team/components/TeamCard/TeamCard.tsx
@@ -1,4 +1,3 @@
-import { useNavigate } from "react-router";
 import { displayLoading, hideLoading } from "../../../uiSlice";
 import { useAppDispatch } from "../../../store/hooks";
 import Button from "../../../components/Button/Button";
@@ -19,7 +18,8 @@ const TeamCard: React.FC<TeamCardProps> = ({ team, loading = "lazy" }) => {
   const { imageUrl, altImageText, name, ridersNames, _id } = team;
   const { fetchTeams } = useTeams();
   const dispatch = useAppDispatch();
-  const navigate = useNavigate();
+
+  const teamDetail = `${teamDetailPage}/${team._id}`;
 
   const deleteTeams = async () => {
     dispatch(displayLoading());
@@ -35,10 +35,6 @@ const TeamCard: React.FC<TeamCardProps> = ({ team, loading = "lazy" }) => {
       dispatch(hideLoading());
       deleteTeamError(error as Error);
     }
-  };
-
-  const navigateToTeamDetailPage = () => {
-    navigate(`${teamDetailPage}/${team._id}`);
   };
 
   return (
@@ -62,7 +58,7 @@ const TeamCard: React.FC<TeamCardProps> = ({ team, loading = "lazy" }) => {
           <Button
             className="details-button"
             children="Details"
-            onClick={navigateToTeamDetailPage}
+            linkTo={teamDetail}
           />
           <Button children="Delete" onClick={deleteTeams} />
         </div>


### PR DESCRIPTION
- Changed 'Details' `button` html element for anchor element
- Added test case for `TeamDetailPage` route from `TeamsPage`. When the user is in `TeamsPage` and click the 'Details' button from a specific team. Tested that team name should appear inside a heading.
