### PR TITLE
Feature/team detail page

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -1,10 +1,10 @@
 import { Suspense } from "react";
 import { Outlet } from "react-router";
-import { Bounce, ToastContainer } from "react-toastify";
-import "react-toastify/dist/ReactToastify.css";
 import Loader from "../Loader/Loader";
 import Header from "../Header/Header";
 import NavMenu from "../NavMenu/NavMenu";
+import { Bounce, ToastContainer } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 import("./App.css");
 
 const App: React.FC = () => {

--- a/src/team/components/TeamCard/TeamCard.tsx
+++ b/src/team/components/TeamCard/TeamCard.tsx
@@ -8,6 +8,7 @@ import { deleteTeamFeedback } from "../../toasts/success/success";
 import { Team } from "../../types";
 import { teamDetailPage } from "../../../router/routes";
 import "./TeamCard.css";
+import { Link } from "react-router";
 
 interface TeamCardProps {
   team: Team;
@@ -39,14 +40,17 @@ const TeamCard: React.FC<TeamCardProps> = ({ team, loading = "lazy" }) => {
 
   return (
     <article className="team-card">
-      <img
-        className="team-card__image"
-        src={imageUrl}
-        alt={altImageText}
-        width={447}
-        height={327}
-        loading={loading}
-      />
+      <Link to={teamDetailRoute}>
+        <img
+          className="team-card__image"
+          src={imageUrl}
+          alt={altImageText}
+          width={447}
+          height={327}
+          loading={loading}
+        />
+      </Link>
+
       <div className="team-card__information">
         <h2 className="team-card__name">{name}</h2>
         <div className="team-card__riders">

--- a/src/team/components/TeamDetail/TeamDetail.tsx
+++ b/src/team/components/TeamDetail/TeamDetail.tsx
@@ -27,6 +27,7 @@ const TeamDetail: React.FC<TeamDetailProps> = ({ team }) => {
         alt={altImageText}
         width={480}
         height={304}
+        fetchPriority="high"
       />
       <div className="team-information">
         <div className="team-information__official-team">
@@ -37,6 +38,7 @@ const TeamDetail: React.FC<TeamDetailProps> = ({ team }) => {
               alt={`${name} is a official team`}
               width={24}
               height={24}
+              fetchPriority="high"
             />
           ) : (
             <img
@@ -44,6 +46,7 @@ const TeamDetail: React.FC<TeamDetailProps> = ({ team }) => {
               alt={`${name} is not a official team`}
               width={24}
               height={24}
+              fetchPriority="high"
             />
           )}
         </div>
@@ -68,9 +71,9 @@ const TeamDetail: React.FC<TeamDetailProps> = ({ team }) => {
                 <li key={championshipTitles.length - position}>
                   <img
                     src="/icons/championship-titles.svg"
-                    alt={`${position + 1} championship titple`}
-                    width={23}
-                    height={23}
+                    alt={`${position + 1} championship title`}
+                    width={24}
+                    height={24}
                   />
                 </li>
               ))}

--- a/src/team/pages/TeamDetailPage/TeamDetailPage.tsx
+++ b/src/team/pages/TeamDetailPage/TeamDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect } from "react";
-import { useParams } from "react-router";
+import { useNavigate, useParams } from "react-router";
 import { useAppDispatch, useAppSelector } from "../../../store/hooks";
 import TeamDetail from "../../components/TeamDetail/TeamDetail";
 import { teamsClient } from "../../client/TeamsClient";
@@ -7,9 +7,11 @@ import { loadTeam } from "../../slice";
 import { displayLoading, hideLoading } from "../../../uiSlice";
 import { loadTeamDetailError } from "../../toasts/errors/errors";
 import Loader from "../../../components/Loader/Loader";
+import { notFoundPage } from "../../../router/routes";
 
 const TeamDetailPage: React.FC = () => {
   const { teamId } = useParams<{ teamId: string }>();
+  const navigate = useNavigate();
   const team = useAppSelector((state) => state.teamsState.team);
   const isLoading = useAppSelector((state) => state.uiState.isLoading);
 
@@ -25,8 +27,10 @@ const TeamDetailPage: React.FC = () => {
     } catch {
       dispatch(hideLoading());
       loadTeamDetailError();
+
+      navigate(notFoundPage);
     }
-  }, [dispatch, teamId]);
+  }, [dispatch, navigate, teamId]);
 
   useEffect(() => {
     fetchTeam();


### PR DESCRIPTION
- Added the link to `TeamDetailPage` to image. If the user clicks on the image will be redirected to `TeamDetailPage`
- Added to `TeamDetailPage` a navigate to `NotFoundPage` if can't load the team. This is to avoid empty image and information in `TeamDetailPage`
- Added fetch priority to images in `TeamDetail` to avoid the render delay