### PR TITLE
Change TeamDetailPage team state management with useState

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -1,11 +1,11 @@
 import { Suspense } from "react";
 import { Outlet } from "react-router";
+import { Bounce, ToastContainer } from "react-toastify";
 import Loader from "../Loader/Loader";
 import Header from "../Header/Header";
 import NavMenu from "../NavMenu/NavMenu";
-import { Bounce, ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
-import("./App.css");
+import "./App.css";
 
 const App: React.FC = () => {
   return (

--- a/src/team/components/TeamDetail/TeamDetail.tsx
+++ b/src/team/components/TeamDetail/TeamDetail.tsx
@@ -38,7 +38,6 @@ const TeamDetail: React.FC<TeamDetailProps> = ({ team }) => {
               alt={`${name} is a official team`}
               width={24}
               height={24}
-              fetchPriority="high"
             />
           ) : (
             <img
@@ -46,7 +45,6 @@ const TeamDetail: React.FC<TeamDetailProps> = ({ team }) => {
               alt={`${name} is not a official team`}
               width={24}
               height={24}
-              fetchPriority="high"
             />
           )}
         </div>

--- a/src/team/pages/TeamDetailPage/TeamDetailPage.tsx
+++ b/src/team/pages/TeamDetailPage/TeamDetailPage.tsx
@@ -1,27 +1,39 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 import { useAppDispatch, useAppSelector } from "../../../store/hooks";
 import TeamDetail from "../../components/TeamDetail/TeamDetail";
 import { teamsClient } from "../../client/TeamsClient";
-import { loadTeam } from "../../slice";
 import { displayLoading, hideLoading } from "../../../uiSlice";
 import { loadTeamDetailError } from "../../toasts/errors/errors";
 import Loader from "../../../components/Loader/Loader";
 import { notFoundPage } from "../../../router/routes";
+import { Team } from "../../types";
 
 const TeamDetailPage: React.FC = () => {
   const { teamId } = useParams<{ teamId: string }>();
   const navigate = useNavigate();
-  const team = useAppSelector((state) => state.teamsState.team);
   const isLoading = useAppSelector((state) => state.uiState.isLoading);
+
+  const [team, setTeam] = useState<Team>({
+    _id: "",
+    name: "",
+    ridersNames: [],
+    debutYear: 0,
+    isOfficialTeam: false,
+    championshipTitles: 0,
+    imageUrl: "",
+    altImageText: "",
+    description: "",
+  });
 
   const dispatch = useAppDispatch();
 
   const fetchTeam = useCallback(async () => {
     dispatch(displayLoading());
+
     try {
       const fetchTeam = await teamsClient.getTeamById(teamId as string);
-      dispatch(loadTeam(fetchTeam));
+      setTeam(fetchTeam);
 
       dispatch(hideLoading());
     } catch {

--- a/src/team/slice/index.ts
+++ b/src/team/slice/index.ts
@@ -3,22 +3,10 @@ import { Team } from "../types";
 
 interface TeamsState {
   teams: Team[];
-  team: Team;
 }
 
 const teamsInitialState: TeamsState = {
   teams: [],
-  team: {
-    _id: "",
-    name: "",
-    ridersNames: ["", ""],
-    debutYear: 0,
-    isOfficialTeam: false,
-    championshipTitles: 0,
-    imageUrl: "",
-    altImageText: "",
-    description: "",
-  },
 };
 
 export const teamsSlice = createSlice({
@@ -31,14 +19,8 @@ export const teamsSlice = createSlice({
         teams: action.payload,
       };
     },
-    loadTeam: (state, action: PayloadAction<Team>) => {
-      return {
-        ...state,
-        team: action.payload,
-      };
-    },
   },
 });
 
-export const { loadTeams, loadTeam } = teamsSlice.actions;
+export const { loadTeams } = teamsSlice.actions;
 export default teamsSlice.reducer;


### PR DESCRIPTION
- Changed the team state management `TeamDetailPage` with `useState` to avoid sharing the team state and that when the user enters the `TeamDetailPage` more than once, the user does not see the previous team data until the new data is rendered.