### PR TITLE
Change 'Details' button name to 'View details'

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ The **Team Image** serves as a key visual highlight, providing immediate recogni
 **teams**
 
 - `loadTeams`: loads an array of teams into the state.
-- `loadTeam`: Loads a single team's details into the state.
 
 ### Data Description
 

--- a/src/team/components/TeamCard/TeamCard.css
+++ b/src/team/components/TeamCard/TeamCard.css
@@ -40,4 +40,5 @@
 
 .details-button {
   background-color: var(--button-secondary-main-color);
+  width: fit-content;
 }

--- a/src/team/components/TeamCard/TeamCard.tsx
+++ b/src/team/components/TeamCard/TeamCard.tsx
@@ -8,7 +8,6 @@ import { deleteTeamFeedback } from "../../toasts/success/success";
 import { Team } from "../../types";
 import { teamDetailPage } from "../../../router/routes";
 import "./TeamCard.css";
-import { Link } from "react-router";
 
 interface TeamCardProps {
   team: Team;
@@ -40,16 +39,14 @@ const TeamCard: React.FC<TeamCardProps> = ({ team, loading = "lazy" }) => {
 
   return (
     <article className="team-card">
-      <Link to={teamDetailRoute}>
-        <img
-          className="team-card__image"
-          src={imageUrl}
-          alt={altImageText}
-          width={447}
-          height={327}
-          loading={loading}
-        />
-      </Link>
+      <img
+        className="team-card__image"
+        src={imageUrl}
+        alt={altImageText}
+        width={447}
+        height={327}
+        loading={loading}
+      />
 
       <div className="team-card__information">
         <h2 className="team-card__name">{name}</h2>
@@ -61,7 +58,7 @@ const TeamCard: React.FC<TeamCardProps> = ({ team, loading = "lazy" }) => {
         <div className="button__container">
           <Button
             className="details-button"
-            children="Details"
+            children="View details"
             linkTo={teamDetailRoute}
           />
           <Button children="Delete" onClick={deleteTeam} />

--- a/src/team/pages/TeamDetailPage/TeamDetailPage.tsx
+++ b/src/team/pages/TeamDetailPage/TeamDetailPage.tsx
@@ -19,7 +19,7 @@ const TeamDetailPage: React.FC = () => {
     name: "",
     ridersNames: [],
     debutYear: 0,
-    isOfficialTeam: false,
+    isOfficialTeam: true,
     championshipTitles: 0,
     imageUrl: "",
     altImageText: "",


### PR DESCRIPTION
- Change 'Details' button name to 'View details' to avoid suspicious link text warning from Wave