### PR TITLE
Add team state management and implement into TeamDetailPage

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The **Team Image** serves as a key visual highlight, providing immediate recogni
 **teams**
 
 - `loadTeams`: loads an array of teams into the state.
+- `loadTeam`: Loads a single team's details into the state.
 
 ### Data Description
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,5 +1,5 @@
 import { configureStore } from "@reduxjs/toolkit";
-import teamsReducer from "../team/slice";
+import teamsReducer from "../team/slice/teamsSlice";
 import uiSliceReducer from "../uiSlice/index";
 
 export const store = configureStore({

--- a/src/team/components/TeamDetail/TeamDetail.tsx
+++ b/src/team/components/TeamDetail/TeamDetail.tsx
@@ -16,7 +16,9 @@ const TeamDetail: React.FC<TeamDetailProps> = ({ team }) => {
     description,
   } = team;
 
-  const championshipTitles: number[] = Array(team.championshipTitles).fill(0);
+  const championshipTitles: number[] = Array(team.championshipTitles).fill(
+    null,
+  );
 
   return (
     <article className="team-detail">

--- a/src/team/hooks/useTeams.ts
+++ b/src/team/hooks/useTeams.ts
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import { loadTeams } from "../slice";
+import { loadTeams } from "../slice/teamsSlice";
 import { useAppSelector, useAppDispatch } from "../../store/hooks";
 import { loadTeamsError } from "../toasts/errors/errors";
 import { displayLoading, hideLoading } from "../../uiSlice";

--- a/src/team/pages/TeamDetailPage/TeamDetailPage.tsx
+++ b/src/team/pages/TeamDetailPage/TeamDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect } from "react";
 import { useNavigate, useParams } from "react-router";
 import { useAppDispatch, useAppSelector } from "../../../store/hooks";
 import TeamDetail from "../../components/TeamDetail/TeamDetail";
@@ -7,26 +7,16 @@ import { displayLoading, hideLoading } from "../../../uiSlice";
 import { loadTeamDetailError } from "../../toasts/errors/errors";
 import Loader from "../../../components/Loader/Loader";
 import { notFoundPage } from "../../../router/routes";
-import { Team } from "../../types";
+import { loadTeam } from "../../slice/teamsSlice";
 
 const TeamDetailPage: React.FC = () => {
-  const { teamId } = useParams<{ teamId: string }>();
   const navigate = useNavigate();
+  const dispatch = useAppDispatch();
+
+  const team = useAppSelector((state) => state.teamsState.team);
   const isLoading = useAppSelector((state) => state.uiState.isLoading);
 
-  const [team, setTeam] = useState<Team>({
-    _id: "",
-    name: "",
-    ridersNames: [],
-    debutYear: 0,
-    isOfficialTeam: true,
-    championshipTitles: 0,
-    imageUrl: "",
-    altImageText: "",
-    description: "",
-  });
-
-  const dispatch = useAppDispatch();
+  const { teamId } = useParams<{ teamId: string }>();
 
   const fetchTeam = useCallback(async () => {
     dispatch(displayLoading());
@@ -35,8 +25,8 @@ const TeamDetailPage: React.FC = () => {
 
     try {
       const fetchTeam = await teamsClient.getTeamById(teamId as string);
-      setTeam(fetchTeam);
 
+      dispatch(loadTeam(fetchTeam));
       dispatch(hideLoading());
     } catch {
       dispatch(hideLoading());
@@ -47,13 +37,19 @@ const TeamDetailPage: React.FC = () => {
   }, [dispatch, navigate, teamId]);
 
   useEffect(() => {
-    fetchTeam();
-  }, [fetchTeam]);
+    if (teamId) {
+      fetchTeam();
+    }
+
+    return () => {
+      dispatch(loadTeam(null));
+    };
+  }, [dispatch, fetchTeam, teamId]);
 
   return (
     <>
       {isLoading && <Loader />}
-      <TeamDetail team={team} />
+      {team && <TeamDetail team={team} />}
     </>
   );
 };

--- a/src/team/slice/teamsSlice.ts
+++ b/src/team/slice/teamsSlice.ts
@@ -3,10 +3,12 @@ import { Team } from "../types";
 
 interface TeamsState {
   teams: Team[];
+  team: Team | null;
 }
 
 const teamsInitialState: TeamsState = {
   teams: [],
+  team: null,
 };
 
 export const teamsSlice = createSlice({
@@ -19,8 +21,14 @@ export const teamsSlice = createSlice({
         teams: action.payload,
       };
     },
+    loadTeam: (state, action: PayloadAction<Team | null>) => {
+      return {
+        ...state,
+        team: action.payload,
+      };
+    },
   },
 });
 
-export const { loadTeams } = teamsSlice.actions;
+export const { loadTeams, loadTeam } = teamsSlice.actions;
 export default teamsSlice.reducer;


### PR DESCRIPTION
This pull request introduces **team state management** using Redux and integrates it into the `TeamDetailPage` component.

### Key Changes

- **Redux State Management**
  - Created a `teamsSlice` to handle team-related state.
  - Defined initial state with `teams` as an empty array and `team` as `null`.
  - Implemented `loadTeams` and `loadTeam` reducers to update the state.

- **`TeamDetailPage` Component Update**
  - Replaced local state with Redux state for managing team details.
  - Modified `useEffect` to fetch team data when `teamId` is present and clear the team state on component unmount.
  - Adjusted rendering to display `Loader` when `isLoading` is `true` and `TeamDetail` when `team` has data.

### Summary

These enhancements improve state management and streamline the integration of team details within the application.
